### PR TITLE
Update canvas to use node-addon-api 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "express": "^4.14.0",
     "mocha": "^3.1.2",
-    "node-addon-api": "0.3.1",
+    "node-addon-api": "1.0.0",
     "standard": "^8.5.0"
   },
   "devDependencies": {},

--- a/src/Canvas.cc
+++ b/src/Canvas.cc
@@ -66,7 +66,8 @@ Canvas::Initialize(Napi::Env& env, Napi::Object& target) {
  * Initialize a Canvas with the given width and height.
  */
 
-Canvas::Canvas(const Napi::CallbackInfo& info) {
+Canvas::Canvas(const Napi::CallbackInfo& info):
+    Napi::ObjectWrap<Canvas>(info) {
   int w = 0, h = 0;
   canvas_type_t t = CANVAS_TYPE_IMAGE;
   if (info[0].IsNumber()) {
@@ -637,10 +638,6 @@ void Canvas::RegisterFont(const Napi::CallbackInfo& info) {
 /*
  * Initialize cairo surface.
  */
-
-Canvas::Canvas(int w, int h, canvas_type_t t) {
-  init(w, h, t);
-}
 
 void Canvas::init(int w, int h, canvas_type_t t) {
   type = t;

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -1,4 +1,3 @@
-
 //
 // Canvas.h
 //
@@ -94,7 +93,6 @@ class Canvas: public Napi::ObjectWrap<Canvas> {
     inline uint8_t *data(){ return cairo_image_surface_get_data(_surface); }
     inline int stride(){ return cairo_image_surface_get_stride(_surface); }
     inline int nBytes(){ return height * stride(); }
-    Canvas(int width, int height, canvas_type_t type);
     void init(int width, int height, canvas_type_t type);
     void resurface();
 

--- a/src/CanvasGradient.cc
+++ b/src/CanvasGradient.cc
@@ -32,7 +32,8 @@ Gradient::Initialize(Napi::Env& env, Napi::Object& target) {
  * Initialize a new CanvasGradient.
  */
 
-Gradient::Gradient(const Napi::CallbackInfo& info) {
+Gradient::Gradient(const Napi::CallbackInfo& info):
+  Napi::ObjectWrap<Gradient>(info) {
   // Linear
   if (4 == info.Length()) {
     _pattern = cairo_pattern_create_linear(
@@ -81,22 +82,6 @@ void Gradient::AddColorStop(const Napi::CallbackInfo& info) {
   } else {
     throw Napi::TypeError::New(info.Env(),"parse color failed");
   }
-}
-
-/*
- * Initialize linear gradient.
- */
-
-Gradient::Gradient(double x0, double y0, double x1, double y1) {
-  _pattern = cairo_pattern_create_linear(x0, y0, x1, y1);
-}
-
-/*
- * Initialize radial gradient.
- */
-
-Gradient::Gradient(double x0, double y0, double r0, double x1, double y1, double r1) {
-  _pattern = cairo_pattern_create_radial(x0, y0, r0, x1, y1, r1);
 }
 
 /*

--- a/src/CanvasGradient.h
+++ b/src/CanvasGradient.h
@@ -17,8 +17,6 @@ class Gradient: public Napi::ObjectWrap<Gradient> {
     static Napi::FunctionReference constructor;
     static void Initialize(Napi::Env& env, Napi::Object& target);
     void AddColorStop(const Napi::CallbackInfo& info);
-    Gradient(double x0, double y0, double x1, double y1);
-    Gradient(double x0, double y0, double r0, double x1, double y1, double r1);
     inline cairo_pattern_t *pattern(){ return _pattern; }
 
   private:

--- a/src/CanvasPattern.cc
+++ b/src/CanvasPattern.cc
@@ -29,7 +29,8 @@ Pattern::Initialize(Napi::Env& env, Napi::Object& target) {
  * Initialize a new CanvasPattern.
  */
 
-Pattern::Pattern(const Napi::CallbackInfo& info) {
+Pattern::Pattern(const Napi::CallbackInfo& info) :
+  Napi::ObjectWrap<Pattern>(info) {
   cairo_surface_t *surface;
 
   Napi::Object obj = info[0].As<Napi::Object>();
@@ -54,14 +55,6 @@ Pattern::Pattern(const Napi::CallbackInfo& info) {
   _pattern = cairo_pattern_create_for_surface(surface);
 }
 
-
-/*
- * Initialize linear gradient.
- */
-
-Pattern::Pattern(cairo_surface_t *surface) {
-  _pattern = cairo_pattern_create_for_surface(surface);
-}
 
 /*
  * Destroy the pattern.

--- a/src/CanvasPattern.h
+++ b/src/CanvasPattern.h
@@ -16,7 +16,6 @@ class Pattern: public Napi::ObjectWrap<Pattern> {
     ~Pattern();
     static Napi::FunctionReference constructor;
     static void Initialize(Napi::Env& env, Napi::Object& target);
-    Pattern(cairo_surface_t *surface);
     inline cairo_pattern_t *pattern() { return _pattern; }
 
   private:

--- a/src/CanvasRenderingContext2d.cc
+++ b/src/CanvasRenderingContext2d.cc
@@ -144,10 +144,6 @@ Context2d::Initialize(Napi::Env& env, Napi::Object& target) {
  * Create a cairo context.
  */
 
-Context2d::Context2d(Canvas *canvas) {
-  init(canvas);
-}
-
 void Context2d::init(Canvas *canvas) {
   _canvas = canvas;
   _context = cairo_create(canvas->surface());
@@ -492,8 +488,9 @@ Context2d::blur(cairo_surface_t *surface, int radius) {
  * Initialize a new Context2d with the given canvas.
  */
 
-Context2d::Context2d(const Napi::CallbackInfo& info) {
-  Napi::Object obj = info[0].As<Napi::Object>();
+Context2d::Context2d(const Napi::CallbackInfo& info) :
+  Napi::ObjectWrap<Context2d>(info) {
+Napi::Object obj = info[0].As<Napi::Object>();
 
   if (!obj.InstanceOf(Canvas::constructor.Value().As<Napi::Function>())) {
     throw Napi::TypeError::New(info.Env(),"Canvas expected");

--- a/src/CanvasRenderingContext2d.h
+++ b/src/CanvasRenderingContext2d.h
@@ -57,7 +57,6 @@ class Context2d: public Napi::ObjectWrap<Context2d> {
     short stateno;
     canvas_state_t *states[CANVAS_MAX_STATES];
     canvas_state_t *state;
-    Context2d(Canvas *canvas);
     void init(Canvas *canvas);
     static Napi::FunctionReference constructor;
     static void Initialize(Napi::Env& env, Napi::Object& target);

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -63,8 +63,17 @@ Image::Initialize(Napi::Env& env, Napi::Object& target) {
  * Initialize a new Image.
  */
 
-Image::Image(const Napi::CallbackInfo& info) : Image() {
-  this->data_mode = DATA_IMAGE;
+Image::Image(const Napi::CallbackInfo& info) :
+  Napi::ObjectWrap<Image>(info),
+  filename(NULL),
+  _data(NULL),
+  _data_len(0),
+  _surface(NULL),
+  width(0),
+  height(0),
+  state(DEFAULT),
+  data_mode(DATA_IMAGE)
+{
 }
 
 /*
@@ -279,19 +288,6 @@ void Image::SetOnerror(const Napi::CallbackInfo& info, const Napi::Value& value)
   } else if (value.IsNull()) {
     this->onerror.Reset();
   }
-}
-
-/*
- * Initialize a new Image.
- */
-
-Image::Image() {
-  filename = NULL;
-  _data = NULL;
-  _data_len = 0;
-  _surface = NULL;
-  width = height = 0;
-  state = DEFAULT;
 }
 
 /*

--- a/src/Image.h
+++ b/src/Image.h
@@ -77,7 +77,6 @@ class Image : public Napi::ObjectWrap<Image> {
     void error(Napi::Error error);
     void loaded(Napi::Env env);
     cairo_status_t load();
-    Image();
 
     enum {
         DEFAULT

--- a/src/ImageData.cc
+++ b/src/ImageData.cc
@@ -31,7 +31,8 @@ ImageData::Initialize(Napi::Env& env, Napi::Object& target) {
  * Initialize a new ImageData object.
  */
 
-ImageData::ImageData(const Napi::CallbackInfo& info) {
+ImageData::ImageData(const Napi::CallbackInfo& info) :
+  Napi::ObjectWrap<ImageData>(info) { 
   Napi::Uint8Array clampedArray;
 
   uint32_t width;

--- a/src/ImageData.h
+++ b/src/ImageData.h
@@ -1,6 +1,6 @@
 
 //
-// ImageData.h
+// Imagedata.h
 //
 // Copyright (c) 2010 LearnBoost <tj@learnboost.com>
 //
@@ -24,7 +24,6 @@ class ImageData: public Napi::ObjectWrap<ImageData> {
     inline int height() { return _height; }
     inline uint8_t *data() { return _data; }
     inline int stride() { return _width * 4; }
-    ImageData(uint8_t *data, int width, int height) : _width(width), _height(height), _data(data) {}
 
   private:
     int _width;

--- a/src/init.cc
+++ b/src/init.cc
@@ -22,7 +22,7 @@
 #define snprintf _snprintf
 #endif
 
-void init(Napi::Env env, Napi::Object exports, Napi::Object module) {
+Napi::Object init(Napi::Env env, Napi::Object exports) {
   Canvas::Initialize(env, exports);
   Image::Initialize(env, exports);
   ImageData::Initialize(env, exports);
@@ -72,6 +72,8 @@ void init(Napi::Env env, Napi::Object exports, Napi::Object module) {
   char freetype_version[10];
   snprintf(freetype_version, 10, "%d.%d.%d", FREETYPE_MAJOR, FREETYPE_MINOR, FREETYPE_PATCH);
   exports.Set("freetypeVersion", freetype_version);
+
+  return exports;
 }
 
 NODE_API_MODULE(canvas, init);


### PR DESCRIPTION
1. Update constructors that take in a CallbackInfo to call the base class
constructor
2. Remove unused constructors
3. Update the module initialization function to use the current
registration callback signature